### PR TITLE
Use dedicated actions and separate steps

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,6 +25,14 @@ jobs:
       run: python -m pip install --upgrade pip -r test-requirements.txt
     - name: Run pytest
       run: pytest
+    - name: Archive coverage
+      uses: actions/upload-artifact@v3
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
+      with:
+        name: coverage
+        path: |
+          coverage.xml
+
   check-style:
     runs-on: ubuntu-latest
     steps:
@@ -39,12 +47,14 @@ jobs:
       uses: actions/checkout@master
     - name: Check code formatting
       uses: psf/black@stable
-  code-cov:
+  code-coverage:
     needs: python-tests
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@master
+    - name: Download coverage artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Check code formatting
       uses: psf/black@stable
   code-cov:
+    needs: python-tests
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,12 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches:
-      - main
-    tags:
-      - '*'
-  pull_request:
+on: [push]
 
 jobs:
   python-tests:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,9 +30,9 @@ jobs:
     - name: Run pytest
       run: pytest
     - name: Check style
-      run: flake8
+      uses: py-actions/flake8@v2
     - name: Check code formatting
-      run: black --check --diff .
+      uses: psf/black@stable
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.10 && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,12 +23,26 @@ jobs:
       run: python -m pip install --upgrade pip -r test-requirements.txt
     - name: Run pytest
       run: pytest
+  check-style:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
     - name: Check style
       uses: py-actions/flake8@v2
+  check-code-formatting:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
     - name: Check code formatting
       uses: psf/black@stable
+  code-cov:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
     - name: Upload coverage to Codecov
-      if: matrix.python-version == 3.10 && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v3
       with:
         verbose: true

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -51,6 +51,8 @@ jobs:
     needs: python-tests
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@master
     - name: Download coverage artifact
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: [push]
+on:
+  - push
+  - pull_request
 
 jobs:
   python-tests:


### PR DESCRIPTION
This pull-request replaces steps for `flake` and `black` by calls to dedicated actions (like you just did for `codecov`), and move `flake`, `black` and `codecov` to dedicated jobs, because, so like `codecov`, they are independent from the matrix parameters, and they can run in parallel.

I also changed the pipeline to be run just on `[push]` (without branch restriction), since I needed the action to be run on the dedicated branch, which I do this pull request from. ~~I removed `on: pull-request` but I should admit I do not know the consequences.~~ **Edit:** I restored `on: pull-request` but I need approval.